### PR TITLE
Updated claimpms to look for Bash via /usr/bin/env

### DIFF
--- a/linux/claimpms.sh
+++ b/linux/claimpms.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #************************************************************************
 # Script to claim a Plex Media Server
 # Will prompt for:


### PR DESCRIPTION
I discovered when running this on an Ubuntu 20.04 system that the script does not seem to work for POSIX shell:

```
root@plex:~# /bin/sh ./claimpms.sh
./claimpms.sh: 21: Syntax error: "(" unexpected
```

However, manually invoking with Bash solved the problem:

```
root@plex:~# /usr/bin/bash ./claimpms.sh
[clears screen]
************************************************************************
* Script to claim a Plex Media Server
* Will prompt for
*     * plex.tv username
*     * plex.tv password
*     * IP Address of your unclaimed Plex Media Server
*
*
* Made by dane22, a Plex community member
* And Mark Walker/ZiGGiMoN, a Plex hobbyist
*
* Version 1.1.0.0
*
* To see the manual, please visit https://github.com/ukdtom/ClaimIt/wiki
************************************************************************
```

Rather than updating the path for the script manually, I've updated it to use `/usr/bin/env` to look for Bash just in case it's installed in an odd location. This should allow the script to work more flexibly.